### PR TITLE
feat(meme-creation): make captions draggable

### DIFF
--- a/src/components/meme-editor.tsx
+++ b/src/components/meme-editor.tsx
@@ -6,6 +6,7 @@ import { Image, Pencil } from "@phosphor-icons/react";
 export type MemeEditorProps = {
   onDrop: (file: File) => void;
   memePicture?: MemePictureProps;
+  onCaptionMove: (index: number, x: number, y: number) => void;
 };
 
 function renderNoPicture() {
@@ -26,17 +27,30 @@ function renderNoPicture() {
   );
 }
 
-function renderMemePicture(memePicture: MemePictureProps, open: () => void) {
+function renderMemePicture(
+  memePicture: MemePictureProps,
+  open: () => void,
+  onCaptionMove: (index: number, x: number, y: number) => void
+) {
   return (
-    <Box width="full" height="full" position="relative" __css={{
-      "&:hover .change-picture-button": {
-        display: "inline-block",
-      },
-      "& .change-picture-button": {
-        display: "none",
-      },
-    }}>
-      <MemePicture {...memePicture} />
+    <Box
+      width="full"
+      height="full"
+      position="relative"
+      __css={{
+        "&:hover .change-picture-button": {
+          display: "inline-block",
+        },
+        "& .change-picture-button": {
+          display: "none",
+        },
+      }}
+    >
+      <MemePicture
+        {...memePicture}
+        onCaptionMove={onCaptionMove}
+        editable={true}
+      />
       <Button
         className="change-picture-button"
         leftIcon={<Icon as={Pencil} boxSize={4} />}
@@ -57,6 +71,7 @@ function renderMemePicture(memePicture: MemePictureProps, open: () => void) {
 export const MemeEditor: React.FC<MemeEditorProps> = ({
   onDrop,
   memePicture,
+  onCaptionMove,
 }) => {
   const { getRootProps, getInputProps, open } = useDropzone({
     onDrop: (files: File[]) => {
@@ -81,7 +96,9 @@ export const MemeEditor: React.FC<MemeEditorProps> = ({
         px={1}
       >
         <input {...getInputProps()} />
-        {memePicture ? renderMemePicture(memePicture, open) : renderNoPicture()}
+        {memePicture
+          ? renderMemePicture(memePicture, open, onCaptionMove)
+          : renderNoPicture()}
       </Box>
     </AspectRatio>
   );

--- a/src/components/meme-picture.tsx
+++ b/src/components/meme-picture.tsx
@@ -1,5 +1,6 @@
 import { Box, Text, useDimensions } from "@chakra-ui/react";
 import { useMemo, useRef } from "react";
+import Draggable from "react-draggable";
 
 export type MemePictureProps = {
   pictureUrl: string;
@@ -9,6 +10,8 @@ export type MemePictureProps = {
     y: number;
   }[];
   dataTestId?: string;
+  onCaptionMove?: (index: number, x: number, y: number) => void;
+  editable?: boolean;
 };
 
 const REF_WIDTH = 800;
@@ -18,7 +21,9 @@ const REF_FONT_SIZE = 36;
 export const MemePicture: React.FC<MemePictureProps> = ({
   pictureUrl,
   texts: rawTexts,
-  dataTestId = '',
+  dataTestId = "",
+  onCaptionMove,
+  editable = false,
 }) => {
   const containerRef = useRef<HTMLDivElement>(null);
   const dimensions = useDimensions(containerRef, true);
@@ -40,6 +45,17 @@ export const MemePicture: React.FC<MemePictureProps> = ({
     };
   }, [boxWidth, rawTexts]);
 
+  const handleDrag = (
+    index: number,
+    e: any,
+    data: { x: number; y: number }
+  ) => {
+    if (onCaptionMove) {
+      const scaleFactor = REF_WIDTH / (boxWidth || 1);
+      onCaptionMove(index, data.x * scaleFactor, data.y * scaleFactor);
+    }
+  };
+
   return (
     <Box
       width="full"
@@ -56,22 +72,29 @@ export const MemePicture: React.FC<MemePictureProps> = ({
       data-testid={dataTestId}
     >
       {texts.map((text, index) => (
-        <Text
+        <Draggable
           key={index}
-          position="absolute"
-          left={text.x}
-          top={text.y}
-          fontSize={fontSize}
-          color="white"
-          fontFamily="Impact"
-          fontWeight="bold"
-          userSelect="none"
-          textTransform="uppercase"
-          style={{ WebkitTextStroke: "1px black" }}
-          data-testid={`${dataTestId}-text-${index}`}
+          position={{ x: text.x, y: text.y }}
+          onStop={(e, data) => handleDrag(index, e, data)}
+          disabled={!editable}
         >
-          {text.content}
-        </Text>
+          <Text
+            position="absolute"
+            fontSize={fontSize}
+            color="white"
+            fontFamily="Impact"
+            fontWeight="bold"
+            userSelect="none"
+            textTransform="uppercase"
+            style={{
+              WebkitTextStroke: "1px black",
+              cursor: editable ? "move" : "default",
+            }}
+            data-testid={`${dataTestId}-text-${index}`}
+          >
+            {text.content}
+          </Text>
+        </Draggable>
       ))}
     </Box>
   );

--- a/src/routes/_authentication/create.tsx
+++ b/src/routes/_authentication/create.tsx
@@ -60,6 +60,14 @@ function CreateMemePage() {
     setTexts(texts.filter((_, i) => i !== index));
   };
 
+  const handleCaptionMove = (index: number, x: number, y: number) => {
+    setTexts((prevTexts) => {
+      const newTexts = [...prevTexts];
+      newTexts[index] = { ...newTexts[index], x, y };
+      return newTexts;
+    });
+  };
+
   const memePicture = useMemo(() => {
     if (!picture) {
       return undefined;
@@ -119,7 +127,11 @@ function CreateMemePage() {
             <Heading as="h2" size="md" mb={2}>
               Upload your picture
             </Heading>
-            <MemeEditor onDrop={handleDrop} memePicture={memePicture} />
+            <MemeEditor
+              onDrop={handleDrop}
+              memePicture={memePicture}
+              onCaptionMove={handleCaptionMove}
+            />
           </Box>
           <Box>
             <Heading as="h2" size="md" mb={2}>


### PR DESCRIPTION
**This merge enhances the meme creation feature by making captions draggable:**

- Draggable Captions: Users can now drag and reposition captions on the meme image, providing more control over the meme’s appearance.
- State Updates: The new caption positions are saved in the application state, ensuring the correct placement is preserved when submitting the meme.

These changes improve the user experience by allowing for greater flexibility in customizing meme captions.